### PR TITLE
feat: add Create and Read endpoints for beans and brew logs with D1 database integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+*.db

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,62 @@
+-- コーヒー豆情報テーブル
+DROP TABLE IF EXISTS beans;
+CREATE TABLE IF NOT EXISTS beans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    origin TEXT,
+    roast_level TEXT,
+    purchase_date DATE,
+    roast_date DATE,
+    photo_url TEXT
+);
+
+-- 抽出記録テーブル
+DROP TABLE IF EXISTS brew_logs;
+CREATE TABLE IF NOT EXISTS brew_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bean_id INTEGER NOT NULL,
+    grind_size TEXT,
+    water_temp INTEGER,
+    bloom_time INTEGER,
+    bloom_water INTEGER,
+    brew_date DATETIME NOT NULL,
+    FOREIGN KEY (bean_id) REFERENCES beans (id)
+);
+
+-- 注湯詳細テーブル
+DROP TABLE IF EXISTS pours;
+CREATE TABLE IF NOT EXISTS pours (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    brew_log_id INTEGER NOT NULL,
+    pour_number INTEGER NOT NULL,
+    pour_amount INTEGER NOT NULL,
+    flow_rate TEXT,
+    FOREIGN KEY (brew_log_id) REFERENCES brew_logs (id)
+);
+
+-- 評価情報テーブル
+DROP TABLE IF EXISTS ratings;
+CREATE TABLE IF NOT EXISTS ratings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    brew_log_id INTEGER NOT NULL,
+    acidity INTEGER,
+    sweetness INTEGER,
+    bitterness INTEGER,
+    overall_score INTEGER,
+    notes TEXT,
+    FOREIGN KEY (brew_log_id) REFERENCES brew_logs (id)
+);
+
+-- 抽出記録に合計注湯量を加えたビュー
+DROP VIEW IF EXISTS brew_logs_with_total;
+CREATE VIEW IF NOT EXISTS brew_logs_with_total AS
+SELECT 
+    bl.*,
+    COALESCE(SUM(p.pour_amount), 0) AS pour_total,
+    COALESCE(bl.bloom_water, 0) + COALESCE(SUM(p.pour_amount), 0) AS total_water
+FROM 
+    brew_logs bl
+LEFT JOIN 
+    pours p ON bl.id = p.brew_log_id
+GROUP BY 
+    bl.id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,140 @@
-import { Hono } from 'hono'
+import { Hono } from 'hono';
+import { Context } from 'hono';
+import { z } from 'zod';
 
-const app = new Hono<{ Bindings: CloudflareBindings }>()
+interface Env {
+  DB: D1Database;
+}
 
-app.get('/', (c) => {
-  return c.text('Hello Hono!')
-})
+const app = new Hono<{ Bindings: Env }>();
 
-export default app
+const beanSchema = z.object({
+  name: z.string(),
+  origin: z.string().optional(),
+  roast_level: z.string().optional(),
+  purchase_date: z.string().optional(),
+  roast_date: z.string().optional(),
+  photo_url: z.string().url().optional(),
+});
+
+const pourSchema = z.object({
+  pour_number: z.number().int().positive(),
+  pour_amount: z.number().positive(),
+  flow_rate: z.number().positive().optional(),
+});
+
+const brewLogSchema = z.object({
+  bean_id: z.number().int().positive(),
+  grind_size: z.string(),
+  water_temp: z.number().positive(),
+  bloom_time: z.number().int().positive(),
+  bloom_water: z.number().positive(),
+  brew_date: z.string(),
+  pours: z.array(pourSchema),
+});
+
+app.post('/beans', async (c: Context<{ Bindings: Env }>) => {
+  try {
+    const bean = await c.req.json();
+    const parsedBean = beanSchema.parse(bean);
+
+    const { name, origin, roast_level, purchase_date, roast_date, photo_url } = parsedBean;
+
+    await c.env.DB.prepare(
+      `INSERT INTO beans (name, origin, roast_level, purchase_date, roast_date, photo_url)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+      .bind(name, origin, roast_level, purchase_date, roast_date, photo_url)
+      .run();
+
+    return c.json({ message: 'Bean added successfully' }, 201);
+  } catch (error) {
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 400);
+    } else {
+      return c.json({ error: 'An unexpected error occurred' }, 400);
+    }
+  }
+});
+
+app.get('/beans', async (c: Context<{ Bindings: Env }>) => {
+  try {
+    const { results } = await c.env.DB.prepare('SELECT * FROM beans').all();
+    return c.json(results);
+  } catch (error) {
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 500);
+    } else {
+      return c.json({ error: 'An unexpected error occurred' }, 500);
+    }
+  }
+});
+
+app.post('/brew-logs', async (c) => {
+  try {
+    const brewLog = await c.req.json();
+    const parsedBrewLog = brewLogSchema.parse(brewLog);
+
+    const { bean_id, grind_size, water_temp, bloom_time, bloom_water, brew_date, pours } = parsedBrewLog;
+
+    const insertResult = await c.env.DB.prepare(
+      `INSERT INTO brew_logs (bean_id, grind_size, water_temp, bloom_time, bloom_water, brew_date)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+      .bind(bean_id, grind_size, water_temp, bloom_time, bloom_water, brew_date)
+      .run();
+
+    if (!insertResult.success) {
+      throw new Error('Failed to insert brew log');
+    }
+
+    const brewLogId = insertResult.meta.last_row_id;
+
+    for (const pour of pours) {
+      const { pour_number, pour_amount, flow_rate } = pour;
+      const insertPour = await c.env.DB.prepare(
+        `INSERT INTO pours (brew_log_id, pour_number, pour_amount, flow_rate)
+         VALUES (?, ?, ?, ?)`
+      )
+        .bind(brewLogId, pour_number, pour_amount, flow_rate)
+        .run();
+
+      if (!insertPour.success) {
+        throw new Error(`Failed to insert pour with pour_number ${pour_number}`);
+      }
+    }
+
+    return c.json({ message: 'Brew log and pours added successfully' }, 201);
+  } catch (error) {
+    return c.json(
+      {
+        error: error instanceof Error ? error.message : 'An unexpected error occurred',
+      },
+      400
+    );
+  }
+});
+
+app.get('/brew-logs', async (c: Context<{ Bindings: Env }>) => {
+  try {
+    const brewLogs = await c.env.DB.prepare('SELECT * FROM brew_logs').all();
+    const results = [];
+
+    for (const brewLog of brewLogs.results) {
+      const pours = await c.env.DB.prepare('SELECT * FROM pours WHERE brew_log_id = ?')
+        .bind(brewLog.id)
+        .all();
+      results.push({ ...brewLog, pours: pours.results });
+    }
+
+    return c.json(results);
+  } catch (error) {
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 500);
+    } else {
+      return c.json({ error: 'An unexpected error occurred' }, 500);
+    }
+  }
+});
+
+export default app;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -41,10 +41,10 @@ enabled = true
 
 # Bind a D1 database. D1 is Cloudflare’s native serverless SQL database.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases
-# [[d1_databases]]
-# binding = "MY_DB"
-# database_name = "my-database"
-# database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+[[d1_databases]]
+binding = "DB"
+database_name = "mame-log"
+database_id = "e53e7a23-7c7f-4a89-8cd4-cc417b3fa792"
 
 # Bind a dispatch namespace. Use Workers for Platforms to deploy serverless functions programmatically on behalf of your customers.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#dispatch-namespace-bindings-workers-for-platforms


### PR DESCRIPTION
- Updated `.gitignore` to exclude `.db` files.
- Introduced `beanSchema`, `pourSchema`, and `brewLogSchema` for input validation using Zod.
- Added POST and GET endpoints for managing beans:
  - POST `/beans`: Insert a new coffee bean record.
  - GET `/beans`: Retrieve all coffee bean records.
- Added POST and GET endpoints for managing brew logs:
  - POST `/brew-logs`: Insert a new brew log with associated pours.
  - GET `/brew-logs`: Retrieve all brew logs with pour details.
- Configured `wrangler.toml` to bind D1 database `mame-log` to the Workers environment.

This update establishes the foundation for tracking coffee brewing logs and associated beans with robust validation and database integration.