### PR TITLE
Update navigation in BeanCapture component

### DIFF
--- a/src/pages/BeanCapture.tsx
+++ b/src/pages/BeanCapture.tsx
@@ -14,7 +14,7 @@ const BeanCapture: React.FC = () => {
     if (beanId) {
       navigate(`/beans/${beanId}/edit`, options);
     } else {
-      navigate('/beans', options);
+      navigate('/beans/new', options);
     }
   };
 


### PR DESCRIPTION
Redirect to '/beans/new' when no beanId is present to improve user experience.