### PR TITLE
Add remote database reset command and refactor SettingsContext for improved settings handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev",
     "deploy": "npm run build && wrangler pages deploy",
-    "reset-db": "npx wrangler d1 execute mame-log --local --file=./schema.sql"
+    "reset-db": "npx wrangler d1 execute mame-log --file=./schema.sql --local",
+    "reset-remote": "npx wrangler d1 execute mame-log --file=./schema.sql --remote"
   },
   "dependencies": {
     "hono": "^4.6.15",

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -31,6 +31,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   };
 
   const saveSettings = async () => {
+    console.log('save', settings)
     try {
       const response = await fetch('/api/settings', {
         method: 'POST',
@@ -61,9 +62,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         if (loadedSettings[settingKey] !== undefined) {
           updatedSettings[settingKey] = loadedSettings[settingKey]!;
         }
-      });
+        if (isDynamicOption(updatedSettings[settingKey]) && isDynamicOption(initialSettings[settingKey])) {
+          updatedSettings[settingKey].dynamicOptions = initialSettings[settingKey].dynamicOptions;
+        }
+    });
   
-      console.log(updatedSettings);
+      console.log('loadedSettings', loadedSettings)
+      console.log('updatedSettings', updatedSettings);
       setSettings(updatedSettings);
     } catch (error) {
       console.error(error);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSettingsContext } from '../context/SettingsContext';
 import { isFixedOption, isDynamicOption } from '../types/Brew';
 import FixedOptionEditor from '../components/settings/FixedOptionEditor';
@@ -8,6 +8,10 @@ const Settings: React.FC = () => {
   const { settings, updateSettings, saveSettings, loadSettings } = useSettingsContext();
   const [localSettings, setLocalSettings] = useState(settings);
 
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
+  
   const handleSave = () => {
     const sanitizedSettings = Object.entries(localSettings).reduce((acc, [key, setting]) => {
       acc[key] = {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -5,31 +5,15 @@ import FixedOptionEditor from '../components/settings/FixedOptionEditor';
 import DynamicOptionEditor from '../components/settings/DynamicOptionEditor';
 
 const Settings: React.FC = () => {
-  const { settings, updateSettings, saveSettings, loadSettings } = useSettingsContext();
+  const { settings, saveSettings, loadSettings } = useSettingsContext();
   const [localSettings, setLocalSettings] = useState(settings);
 
   useEffect(() => {
     setLocalSettings(settings);
   }, [settings]);
-  
-  const handleSave = () => {
-    const sanitizedSettings = Object.entries(localSettings).reduce((acc, [key, setting]) => {
-      acc[key] = {
-        ...setting,
-        ...(isFixedOption(setting) && {
-          fixedOptions: setting.fixedOptions
-            ?.flatMap((option) => {
-              if (typeof option !== 'string') return option;
-              const trimmed = option.trim();
-              return trimmed ? trimmed : [];
-            }) as (string | number)[] || undefined,
-        }),
-      };
-      return acc;
-    }, {} as typeof localSettings);
-    setLocalSettings(sanitizedSettings);
-    updateSettings(sanitizedSettings);
-    saveSettings();
+
+  const handleSave = async () => {
+    await saveSettings(localSettings);
     alert("設定が保存されました！");
   };
 


### PR DESCRIPTION
Introduce a new command for resetting the remote database and enhance the SettingsContext by removing the updateSettings function. The saveSettings function now better handles fixed options, and the Settings component has been updated to utilize this new implementation.