### PR TITLE
Add offset support for dynamic brew options

### DIFF
--- a/src/components/settings/DynamicOptionEditor.tsx
+++ b/src/components/settings/DynamicOptionEditor.tsx
@@ -7,7 +7,7 @@ interface DynamicOptionEditorProps {
 }
 
 const DynamicOptionEditor: React.FC<DynamicOptionEditorProps> = ({ setting, onChange }) => {
-  const handleDynamicValueChange = (field: 'baseAmountPerCup' | 'stepSize' | 'numSteps', value: number) => {
+  const handleDynamicValueChange = (field: 'baseAmountPerCup' | 'stepSize' | 'numSteps' | 'offset', value: number) => {
     onChange({
       ...setting,
       [field]: value,
@@ -48,6 +48,18 @@ const DynamicOptionEditor: React.FC<DynamicOptionEditorProps> = ({ setting, onCh
           value={setting.numSteps || ''}
           onChange={(e) =>
             handleDynamicValueChange('numSteps', Number(e.target.value))
+          }
+          className="block border rounded-md p-2 w-full"
+        />
+      </div>
+      <div className="mb-2">
+        <label className="block text-sm font-medium">調整値</label>
+        <input
+          type="string"
+          inputMode="numeric"
+          value={setting.offset || 0}
+          onChange={(e) =>
+            handleDynamicValueChange('offset', Number(e.target.value))
           }
           className="block border rounded-md p-2 w-full"
         />

--- a/src/settings/DefaultBrewSettings.ts
+++ b/src/settings/DefaultBrewSettings.ts
@@ -16,7 +16,8 @@ const beanAmount: DynamicBrewSettingOption<number> = {
   isNumeric: true,
   baseAmountPerCup: 10, // 1カップにつき10g
   stepSize: 2,          // 増減幅2g
-  numSteps: 5           // 5段階
+  numSteps: 5,          // 5段階
+  offset: 0
 };
 
 const grindSize: FixedBrewSettingOption<string> = {
@@ -44,7 +45,8 @@ const bloomWaterAmount: DynamicBrewSettingOption<number> = {
   isNumeric: true,
   baseAmountPerCup: 20, // 1カップにつき20ml
   stepSize: 10,         // 増減幅 10ml
-  numSteps: 6           // 6段階
+  numSteps: 6,          // 6段階
+  offset: 10
 };
 
 const bloomTime: FixedBrewSettingOption<number> = {

--- a/src/types/Brew.ts
+++ b/src/types/Brew.ts
@@ -36,6 +36,7 @@ export interface DynamicBrewSettingOption<T> extends BaseSettingOption<T> {
   baseAmountPerCup: number; // カップ数に対する基本量
   stepSize: number;         // 増減幅
   numSteps: number;         // 段階数
+  offset: number;           // 調整値
 }
 
 export type BrewSettingOption<T> = FixedBrewSettingOption<T> | DynamicBrewSettingOption<T>;
@@ -52,10 +53,11 @@ function generateDynamicOptions<T>(
   cups: number,
   baseAmountPerCup: number,
   stepSize: number,
-  numSteps: number
+  numSteps: number,
+  offset: number
 ): T[] {
   return Array.from({ length: numSteps }, (_, i) => 
-    cups * baseAmountPerCup + (i - Math.floor(numSteps / 2)) * stepSize
+    cups * baseAmountPerCup + (i - Math.floor(numSteps / 2)) * stepSize + offset
   ).filter(option => option > 0).map(option => option as T);
 }
 
@@ -64,7 +66,7 @@ export const generateOptions = <T>(
   cups: number = 1
 ): T[] => {
   if (isDynamicOption(setting)) {
-    return generateDynamicOptions(cups, setting.baseAmountPerCup, setting.stepSize, setting.numSteps);
+    return generateDynamicOptions(cups, setting.baseAmountPerCup, setting.stepSize, setting.numSteps, setting.offset);
   }
   if (isFixedOption(setting)) {
     return setting.fixedOptions ?? [];


### PR DESCRIPTION
- Updated `DynamicBrewSettingOption` to include an `offset` property.
- Modified `generateDynamicOptions` to account for the `offset` value.
- Added an input field for `offset` in `DynamicOptionEditor` to allow user adjustments.
- Updated default brew settings to include `offset` values where applicable.