### PR TITLE
Display cumulative water amount for each pour in brew details and form

### DIFF
--- a/src/pages/BrewDetails.tsx
+++ b/src/pages/BrewDetails.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useBrewContext } from '../context/BrewContext';
 import StarRating from '../components/StarRating';
-import { Brew } from '../types/Brew';
+import { Brew, totalWaterAmount } from '../types/Brew';
 import { formatLocalDateTime } from '../utils/date';
 
 const BrewDetails: React.FC = () => {
@@ -64,11 +64,11 @@ const BrewDetails: React.FC = () => {
         {isPositive(brew.bloom_time) && (<p><strong>蒸らし時間:</strong> {brew.bloom_time} [秒]</p>)}
 
         {isPositive(brew.pours?.length) && (<div>
-          <strong>注湯:</strong>
+          <strong>注湯:</strong> (カッコ内は累計)
           <ul className="list-disc pl-5">
             {brew.pours?.map((pourAmount, index) => (
               <li key={index}>
-                {index + 1}湯目: {pourAmount} [ml]
+                {index + 1}湯目: {pourAmount} ({totalWaterAmount(brew, index)}) [ml]
               </li>
             ))}
           </ul>

--- a/src/pages/BrewForm.tsx
+++ b/src/pages/BrewForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Bean } from '../types/Bean';
-import { Brew, generateOptions } from '../types/Brew';
+import { Brew, generateOptions, totalWaterAmount } from '../types/Brew';
 import { useBrewContext } from '../context/BrewContext';
 import StarRating from '../components/StarRating';
 import { useSettingsContext } from '../context/SettingsContext';
@@ -142,7 +142,7 @@ const BrewForm: React.FC = () => {
       );
     });
   };
-    
+
   if (!brew) return <div>読み込み中...</div>;
 
   return (
@@ -193,7 +193,10 @@ const BrewForm: React.FC = () => {
                   className="mt-1 block w-full border rounded-md p-2"
                   required
                 />
-              </div>
+                <label className="block text-sm font-medium">
+                  湯量: {totalWaterAmount(brew, index)} [ml]
+                </label>
+                </div>
                 {index === (brew?.pours ?? []).length - 1 && (
                 <button
                   type="button"

--- a/src/types/Brew.ts
+++ b/src/types/Brew.ts
@@ -77,3 +77,9 @@ export const generateOptions = <T>(
 export type BrewSettings = {
   [key: string]: BrewSettingOption<string | number>;
 };
+
+export const totalWaterAmount = (brew: Brew, pourIndex: number): number => {
+  const bloomWaterAmount = brew.bloom_water_amount ?? 0;
+  const pourAmount = brew.pours ? brew.pours.slice(0, pourIndex + 1).reduce((sum, value) => sum + value, 0) : 0;
+  return bloomWaterAmount + pourAmount;
+}


### PR DESCRIPTION
- Added a `totalWaterAmount` utility function to calculate the cumulative water amount for a given pour index.
- Updated `BrewDetails` to show cumulative water amounts next to each pour in the details view.
- Enhanced `BrewForm` to display the cumulative water amount dynamically below each pour input field.
- Improved user clarity by indicating total water usage alongside individual pour amounts.