### PR TITLE
Refactoring/misc

### DIFF
--- a/src/components/settings/DynamicOptionEditor.tsx
+++ b/src/components/settings/DynamicOptionEditor.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { DynamicBrewSettingOption, generateOptions } from '../../types/Brew';
+import { DynamicBrewSettingOption, generateOptions } from '../../types/Settings';
 
 interface DynamicOptionEditorProps {
   setting: DynamicBrewSettingOption<number | string>;
   onChange: (updatedSetting: DynamicBrewSettingOption<number | string>) => void;
+  previewCups: number;
 }
 
-const DynamicOptionEditor: React.FC<DynamicOptionEditorProps> = ({ setting, onChange }) => {
+const DynamicOptionEditor: React.FC<DynamicOptionEditorProps> = ({ setting, onChange, previewCups }) => {
   const handleDynamicValueChange = (field: 'baseAmountPerCup' | 'stepSize' | 'numSteps' | 'offset', value: number) => {
     onChange({
       ...setting,
@@ -65,9 +66,9 @@ const DynamicOptionEditor: React.FC<DynamicOptionEditorProps> = ({ setting, onCh
         />
       </div>
       <div className="mb-2">
-        <label className="text-sm font-medium">1カップの場合の選択肢</label>
+        <label className="text-sm font-medium">{previewCups}カップの場合の選択肢</label>
         <div className="p-2 border rounded-md bg-gray-50">
-          {generateOptions(setting).map((option, index) => (
+          {generateOptions(setting, previewCups).map((option, index) => (
               <span
                 key={index}
                 className="text-center p-1 bg-blue-100 rounded-md m-1"

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { BrewSettings, isDynamicOption, isFixedOption } from '../types/Brew';
+import { BrewSettings } from '../types/Settings';
 import { DefaultBrewSettings as initialSettings } from '../settings/DefaultBrewSettings';
 
 interface SettingsContextProps {

--- a/src/pages/BrewForm.tsx
+++ b/src/pages/BrewForm.tsx
@@ -194,7 +194,7 @@ const BrewForm: React.FC = () => {
                   required
                 />
                 <label className="block text-sm font-medium">
-                  湯量: {totalWaterAmount(brew, index)} [ml]
+                  湯量の累計: {totalWaterAmount(brew, index)} [ml]
                 </label>
                 </div>
                 {index === (brew?.pours ?? []).length - 1 && (

--- a/src/pages/BrewForm.tsx
+++ b/src/pages/BrewForm.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Bean } from '../types/Bean';
-import { Brew, generateOptions, totalWaterAmount } from '../types/Brew';
+import { Brew, totalWaterAmount } from '../types/Brew';
+import { generateOptions } from '../types/Settings';
 import { useBrewContext } from '../context/BrewContext';
 import StarRating from '../components/StarRating';
 import { useSettingsContext } from '../context/SettingsContext';

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSettingsContext } from '../context/SettingsContext';
-import { isFixedOption, isDynamicOption } from '../types/Brew';
+import { isFixedOption, isDynamicOption } from '../types/Settings';
 import FixedOptionEditor from '../components/settings/FixedOptionEditor';
 import DynamicOptionEditor from '../components/settings/DynamicOptionEditor';
 
 const Settings: React.FC = () => {
   const { settings, updateSettings, saveSettings, loadSettings } = useSettingsContext();
+  const [previewCups, setPreviewCups] = useState<number>(1);
 
   const handleSave = async () => {
     const sanitizedSettings = Object.entries(settings).reduce((acc, [key, setting]) => {
@@ -44,10 +45,21 @@ const Settings: React.FC = () => {
                 key={key}
                 setting={setting}
                 onChange={(newSetting) => updateSettings(key, newSetting)}
+                previewCups={previewCups}
               />
             )}
           </div>
         ))}
+        <div className="mb-6 border p-4 rounded-md">
+          <h2 className="text-xl font-semibold mb-2">プレビューのカップ数</h2>
+          <input
+            type="number"
+            min="1"
+            value={previewCups}
+            onChange={(e) => setPreviewCups(Number(e.target.value))}
+            className="w-full p-2 border rounded-md"
+          />
+        </div>
         <button type="submit" className="bg-blue-500 text-white p-2 rounded-md">
           設定を保存する
         </button>

--- a/src/types/Brew.ts
+++ b/src/types/Brew.ts
@@ -19,65 +19,6 @@ export interface Brew {
   notes?: string;
 }
 
-export interface BaseSettingOption<T> {
-  key: keyof Brew;           // 対応するBrewのプロパティ名
-  displayName: string;       // 項目の表示名
-  isNumeric: boolean;        // 項目が数字かどうか
-  unitLabel?: string;        // 項目の単位（例: "ml", "g"）
-}
-
-export interface FixedBrewSettingOption<T> extends BaseSettingOption<T> {
-  type: 'fixed';
-  fixedOptions: T[];        // 固定選択肢（動的生成がない場合）
-}
-
-export interface DynamicBrewSettingOption<T> extends BaseSettingOption<T> {
-  type: 'dynamic';
-  baseAmountPerCup: number; // カップ数に対する基本量
-  stepSize: number;         // 増減幅
-  numSteps: number;         // 段階数
-  offset: number;           // 調整値
-}
-
-export type BrewSettingOption<T> = FixedBrewSettingOption<T> | DynamicBrewSettingOption<T>;
-
-export function isFixedOption<T>(setting: BrewSettingOption<T>): setting is FixedBrewSettingOption<T> {
-  return setting.type === 'fixed'
-}
-
-export function isDynamicOption<T>(setting: BrewSettingOption<T>): setting is DynamicBrewSettingOption<T> {
-  return setting.type === 'dynamic'
-}
-
-function generateDynamicOptions<T>(
-  cups: number,
-  baseAmountPerCup: number,
-  stepSize: number,
-  numSteps: number,
-  offset: number
-): T[] {
-  return Array.from({ length: numSteps }, (_, i) => 
-    cups * baseAmountPerCup + (i - Math.floor(numSteps / 2)) * stepSize + offset
-  ).filter(option => option > 0).map(option => option as T);
-}
-
-export const generateOptions = <T>(
-  setting: BrewSettingOption<T>,
-  cups: number = 1
-): T[] => {
-  if (isDynamicOption(setting)) {
-    return generateDynamicOptions(cups, setting.baseAmountPerCup, setting.stepSize, setting.numSteps, setting.offset);
-  }
-  if (isFixedOption(setting)) {
-    return setting.fixedOptions ?? [];
-  }
-  return [];
-};
-
-export type BrewSettings = {
-  [key: string]: BrewSettingOption<string | number>;
-};
-
 export const totalWaterAmount = (brew: Brew, pourIndex: number): number => {
   const bloomWaterAmount = brew.bloom_water_amount ?? 0;
   const pourAmount = brew.pours ? brew.pours.slice(0, pourIndex + 1).reduce((sum, value) => sum + value, 0) : 0;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,0 +1,60 @@
+import { Brew } from './Brew'
+
+export interface BaseSettingOption<T> {
+  key: keyof Brew;           // 対応するBrewのプロパティ名
+  displayName: string;       // 項目の表示名
+  isNumeric: boolean;        // 項目が数字かどうか
+  unitLabel?: string;        // 項目の単位（例: "ml", "g"）
+}
+
+export interface FixedBrewSettingOption<T> extends BaseSettingOption<T> {
+  type: 'fixed';
+  fixedOptions: T[];        // 固定選択肢（動的生成がない場合）
+}
+
+export interface DynamicBrewSettingOption<T> extends BaseSettingOption<T> {
+  type: 'dynamic';
+  baseAmountPerCup: number; // カップ数に対する基本量
+  stepSize: number;         // 増減幅
+  numSteps: number;         // 段階数
+  offset: number;           // 調整値
+}
+
+export type BrewSettingOption<T> = FixedBrewSettingOption<T> | DynamicBrewSettingOption<T>;
+
+export function isFixedOption<T>(setting: BrewSettingOption<T>): setting is FixedBrewSettingOption<T> {
+  return setting.type === 'fixed'
+}
+
+export function isDynamicOption<T>(setting: BrewSettingOption<T>): setting is DynamicBrewSettingOption<T> {
+  return setting.type === 'dynamic'
+}
+
+function generateDynamicOptions<T>(
+  cups: number,
+  baseAmountPerCup: number,
+  stepSize: number,
+  numSteps: number,
+  offset: number
+): T[] {
+  return Array.from({ length: numSteps }, (_, i) => 
+    cups * baseAmountPerCup + (i - Math.floor(numSteps / 2)) * stepSize + offset
+  ).filter(option => option > 0).map(option => option as T);
+}
+
+export const generateOptions = <T>(
+  setting: BrewSettingOption<T>,
+  cups: number = 1
+): T[] => {
+  if (isDynamicOption(setting)) {
+    return generateDynamicOptions(cups, setting.baseAmountPerCup, setting.stepSize, setting.numSteps, setting.offset);
+  }
+  if (isFixedOption(setting)) {
+    return setting.fixedOptions ?? [];
+  }
+  return [];
+};
+
+export type BrewSettings = {
+  [key: string]: BrewSettingOption<string | number>;
+};


### PR DESCRIPTION
- Updated `DynamicOptionEditor` to support a `previewCups` prop for dynamic option previews.
- Integrated `previewCups` state into the `Settings` page, allowing users to adjust the number of cups for preview dynamically.
- Updated `generateOptions` usage to reflect the selected `previewCups`.