### PR TITLE
Refactor routing and implement user-restricted image access

### DIFF
--- a/src/api/beans.ts
+++ b/src/api/beans.ts
@@ -43,7 +43,7 @@ app.post('/', async (c: Context<{ Bindings: Env }>) => {
       const photoArrayBuffer = photoBuffer.buffer; // BufferをArrayBufferに変換
     
       await c.env.MAME_LOG_IMAGES.put(photoKey, photoArrayBuffer, {
-        metadata: { contentType: "image/png" },
+        metadata: { contentType: "image/png", user_id: user.id },
       });
     }
 
@@ -102,7 +102,7 @@ app.put('/:id', async (c: Context<{ Bindings: Env }>) => {
       const photoArrayBuffer = photoBuffer.buffer; // BufferをArrayBufferに変換
     
       await c.env.MAME_LOG_IMAGES.put(photoKey, photoArrayBuffer, {
-        metadata: { contentType: "image/png" },
+        metadata: { contentType: "image/png", user_id: user.id },
       });
     }
 

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,0 +1,54 @@
+import { Hono, Context } from 'hono'
+import { Env } from './index'
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get('/coffee-labels/:id', async (c: Context<{ Bindings: Env }>) => {
+  try {
+    const { id } = c.req.param();
+
+    if (!id) {
+      return c.json({ error: "Image ID is required" }, 400);
+    }
+
+    // 認証ユーザーの情報を取得
+    const user = c.get('user');
+    if (!user || !user.id) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // KVストアのKeyを生成
+    const photoKey = `/images/coffee-labels/${id}`;
+
+    // KVストアから画像データとメタデータを取得
+    const { value: imageData, metadata } = await c.env.MAME_LOG_IMAGES.getWithMetadata(photoKey, { type: 'arrayBuffer' });
+    if (!imageData || !metadata) {
+      return c.json({ error: "Image not found" }, 404);
+    }
+
+    // メタデータからuser_idを取得
+    const metadataUserId = (metadata as { user_id?: number })?.user_id;
+    if (!metadataUserId || metadataUserId !== user.id) {
+      return c.json({ error: "Unauthorized access to this image" }, 403);
+    }
+
+    // メタデータからContent-Typeを取得
+    const contentType = (metadata as { contentType?: string })?.contentType;
+    if (!contentType) {
+      return c.json({ error: "Content-Type missing in metadata" }, 500);
+    }
+
+    // 画像データを返却
+    return new Response(imageData, {
+      headers: {
+        'Content-Type': contentType, // KVに保存されたContent-Type
+        'Cache-Control': 'public, max-age=3600', // キャッシュを有効化
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching image:", error);
+    return c.json({ error: "Internal Server Error" }, 500);
+  }
+});
+
+export default app;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Hono, Context } from 'hono'
+import { Hono } from 'hono'
 import { renderToString } from 'react-dom/server'
 import beans from './api/beans'
 import brews from './api/brews'
@@ -9,6 +9,7 @@ import Google from '@auth/core/providers/google'
 import { HTTPException } from 'hono/http-exception'
 import users from './api/users'
 import { requireUserMiddleware } from './api/authMiddleware';
+import images from './images'
 
 export interface Env {
   DB: D1Database;
@@ -44,6 +45,7 @@ app.use('/api/auth/*', (c, next) => {
   }
   return authHandler()(c, next);
 });
+
 app.use('*', verifyAuth())
 
 app.use('*', requireUserMiddleware);
@@ -53,46 +55,7 @@ app.route('/api/beans', beans)
 app.route('/api/brews', brews)
 app.route('/api/analyze', analyze)
 app.route('/api/settings', settings)
-app.get('/api/protected', (c) => {
-  const auth = c.get('authUser')
-  const googleId = auth.user?.id;
-  const email = auth.user?.emailVerified;
-  const name = auth.user?.name;
-  const photoUrl = auth.user?.image;
-  return c.json({auth, googleId, email, name, photoUrl});
-})
-app.get('/images/coffee-labels/:id', async (c: Context<{ Bindings: Env }>) => {
-  try {
-    const { id } = c.req.param();
-
-    if (!id) {
-      return c.json({ error: "Image ID is required" }, 400);
-    }
-
-    // KVストアのKeyを生成
-    const photoKey = `/images/coffee-labels/${id}`;
-
-    // KVストアから画像データを取得
-    const imageData = await c.env.MAME_LOG_IMAGES.get(photoKey, { type: 'arrayBuffer' });
-    const metadata = await c.env.MAME_LOG_IMAGES.getWithMetadata(photoKey);
-    const contentType = (metadata?.metadata as { contentType?: string })?.contentType;
-
-    if (!imageData || !contentType) {
-      return c.json({ error: "Image not found" }, 404);
-    }
-
-    // 画像データを返却
-    return new Response(imageData, {
-      headers: {
-        'Content-Type': contentType, // KVに保存されたContent-Type
-        'Cache-Control': 'public, max-age=3600', // キャッシュを有効化
-      },
-    });
-  } catch (error) {
-    console.error("Error fetching image:", error);
-    return c.json({ error: "Internal Server Error" }, 500);
-  }
-});
+app.route('/images', images)
 
 app.get('*', (c) => {
   return c.html(


### PR DESCRIPTION
- Migrated routing structure from `react-router-dom` to `createBrowserRouter` and `RouterProvider` for improved flexibility and maintainability.
- Added a modal to the `Settings` page to prevent navigation with unsaved changes, leveraging `useBlocker`.
- Enhanced KV storage metadata in the `/api/beans` endpoint to include `user_id` for user-specific data handling.
- Implemented a new `/images` API for retrieving coffee label images with access control based on the authenticated user's `user_id`.
- Removed deprecated `/images/coffee-labels/:id` route and centralized image-related logic in a dedicated `images.ts` file.
- Updated imports and cleaned up redundant code in `index.tsx`.