### PR TITLE
Refactor route structure: centralize providers and organize routes by access level

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, useParams } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
+import Home from './pages/Home';
 import Dashboard from './pages/Dashboard';
 import BrewForm from './pages/BrewForm';
 import BrewList from './pages/BrewList';
@@ -9,198 +10,68 @@ import Settings from './pages/Settings';
 import BeanForm from './pages/BeanForm';
 import BeanList from './pages/BeanList';
 import BeanDetails from './pages/BeanDetails';
-import { BrewProvider } from './context/BrewContext';
 import BeanCapture from './pages/BeanCapture';
-import { SettingsProvider } from './context/SettingsContext';
 import TermsAgreement from './pages/TermsAgreement';
-import Home from './pages/Home';
+import PublicRoutes from './routes/PublicRoutes';
+import AuthRoutes from './routes/AuthRoutes';
+import UserRoutes from './routes/UserRoutes';
 import { AuthProvider } from './context/AuthContext';
+import { BrewProvider } from './context/BrewContext';
+import { SettingsProvider } from './context/SettingsContext';
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <div className="flex flex-col min-h-screen bg-gray-100">
-        <Navbar />
-        <main className="flex-grow container mx-auto p-4">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/signup" element={<TermsAgreement />} />
-            <Route
-              path="/dashboard"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <Dashboard />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanList />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/new"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/new/capture"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanCapture />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/:beanId"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanDetails />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/:beanId/capture"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanCapture />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/:beanId/edit"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BeanForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/beans/:beanId/brews/new"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/brews"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewList />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/brews/new"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/brews/:brewId"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewDetails />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/brews/:brewId/edit"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/brews/:baseBrewId/brews/new"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <BrewForm />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-            <Route
-              path="/settings"
-              element={
-                <AuthProvider>
-                  <BrewProvider>
-                    <SettingsProvider>
-                      <Settings />
-                    </SettingsProvider>
-                  </BrewProvider>
-                </AuthProvider>
-              }
-            />
-          </Routes>
-        </main>
-        {/* フッター */}
-        <footer className="bg-gray-800 text-white text-center p-4">
-          <p>&copy; 2025 <a target="_blank" href="https://x.com/takatama_jp">@takatama_jp</a>. All rights reserved.</p>
-        </footer>
-      </div>
-    </Router>
+    <AuthProvider> {/* 一つだけ定義しないと認証状態がバラバラになる */}
+      <Router>
+        <div className="flex flex-col min-h-screen bg-gray-100">
+          <Navbar />
+          <main className="flex-grow container mx-auto p-4">
+            <Routes>
+              {/* 公開ルート */}
+              <Route element={<PublicRoutes />}>
+                <Route path="/" element={<Home />} />
+              </Route>
+
+              {/* Googleログインが必要なルート */}
+              <Route element={
+                <AuthRoutes />
+              }>
+                <Route path="/signup" element={<TermsAgreement />} />
+              </Route>
+
+              {/* 利用登録が必要なルート */}
+              <Route element={
+                <BrewProvider>
+                  <SettingsProvider>
+                    <UserRoutes />
+                  </SettingsProvider>
+                </BrewProvider>
+              }>
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/beans" element={<BeanList />} />
+                <Route path="/beans/new" element={<BeanForm />} />
+                <Route path="/beans/new/capture" element={<BeanCapture />} />
+                <Route path="/beans/:beanId" element={<BeanDetails />} />
+                <Route path="/beans/:beanId/capture" element={<BeanCapture />} />
+                <Route path="/beans/:beanId/edit" element={<BeanForm />} />
+                <Route path="/beans/:beanId/brews/new" element={<BrewForm />} />
+                <Route path="/brews" element={<BrewList />} />
+                <Route path="/brews/new" element={<BrewForm />} />
+                <Route path="/brews/:brewId" element={<BrewDetails />} />
+                <Route path="/brews/:brewId/edit" element={<BrewForm />} />
+                <Route path="/brews/:baseBrewId/brews/new" element={<BrewForm />} />
+                <Route path="/settings" element={<Settings />} />
+              </Route>
+            </Routes>
+          </main>
+          <footer className="bg-gray-800 text-white text-center p-4">
+            <p>
+              &copy; 2025 <a target="_blank" href="https://x.com/takatama_jp">@takatama_jp</a>. All rights reserved.
+            </p>
+          </footer>
+        </div>
+      </Router>
+    </AuthProvider>
   );
 };
 

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Outlet, Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const AuthRoutes: React.FC = () => {
+  const { isSignedIn, isRegistered } = useAuth();
+
+  if (!isSignedIn) {
+    // return <Navigate to="/api/auth/signin" />;
+    window.location.href = '/api/auth/signin'; // 外部リンクへのリダイレクト
+    return null; // コンポーネントをレンダリングしない
+  }
+
+  if (isRegistered) {
+    return <Navigate to="/dashboard" />;
+  }
+  
+  return <Outlet />;
+}
+
+export default AuthRoutes;

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Outlet, Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const PublicRoutes: React.FC = () => {
+  const { isRegistered } = useAuth();
+
+  if (isRegistered) {
+    return <Navigate to="/dashboard" />;
+  }
+
+  return <Outlet />; // 子ルートをレンダリング
+};
+
+export default PublicRoutes;

--- a/src/routes/UserRoutes.tsx
+++ b/src/routes/UserRoutes.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const UserRoutes: React.FC = () => {
+  const { isSignedIn, isRegistered } = useAuth();
+
+  if (!isSignedIn) {
+    // return <Navigate to="/api/auth/signin" />;
+    window.location.href = '/api/auth/signin'; // 外部リンクへのリダイレクト
+    return null; // コンポーネントをレンダリングしない
+  }
+
+  if (!isRegistered) {
+    return <Navigate to="/signup" />;
+  }
+
+  return <Outlet />
+};
+
+export default UserRoutes;


### PR DESCRIPTION
- Moved AuthProvider, BrewProvider, and SettingsProvider to wrap specific route groups.
- Introduced `PublicRoutes`, `AuthRoutes`, and `UserRoutes` components for better separation of access levels.
- Simplified nested provider usage and ensured consistent authentication state management.
- Improved readability and maintainability of the App component.