### PR TITLE
Enhance photo handling by prioritizing local photo data and improve UI consistency

### DIFF
--- a/src/pages/BeanDetails.tsx
+++ b/src/pages/BeanDetails.tsx
@@ -46,9 +46,9 @@ const BeanDetail: React.FC = () => {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">{bean.name}</h1>
-      {bean.photo_url && (
+      {(bean.photo_data_url || bean.photo_url) && (
         <img
-          src={bean.photo_url}
+          src={bean.photo_data_url || bean.photo_url}
           alt={bean.name}
           className="mb-4 w-32 h-32 object-cover"
         />

--- a/src/pages/BeanForm.tsx
+++ b/src/pages/BeanForm.tsx
@@ -127,7 +127,7 @@ const BeanForm: React.FC = () => {
       <button
           type="button"
           onClick={handleNavigateToCapture}
-          className="bg-green-500 text-white py-2 px-4 rounded-md mr-2"
+          className="bg-green-500 text-white py-2 px-4 rounded-md mr-2 mb-4"
         >
           AIでラベルを解析
       </button>

--- a/src/pages/BeanList.tsx
+++ b/src/pages/BeanList.tsx
@@ -10,9 +10,9 @@ interface BeanListItemProps {
 const BeanListItem: React.FC<BeanListItemProps> = ({ bean }) => {
   return (
     <li key={bean.id} className="p-4 border rounded-md flex items-center">
-      {bean.photo_url && (
+      {bean.photo_data_url || bean.photo_url && (
         <img
-          src={bean.photo_url}
+          src={bean.photo_data_url || bean.photo_url}
           alt={bean.name}
           className="w-16 h-16 object-cover rounded-full mr-4"
         />


### PR DESCRIPTION
- Updated `BeanDetails` and `BeanList` components to prioritize `photo_data_url` over `photo_url` for displaying photos.
- Added fallback to use `photo_url` if `photo_data_url` is not available.
- Adjusted styling in `BeanForm` to add margin-bottom (`mb-4`) for improved spacing.
- Improved overall user experience by ensuring photos display promptly using local data when available.