### PR TITLE
Enhance photo handling by prioritizing local photo data and improve UI consistency

### DIFF
--- a/src/pages/BeanForm.tsx
+++ b/src/pages/BeanForm.tsx
@@ -55,6 +55,8 @@ const BeanForm: React.FC = () => {
       }
   
       const createdBean: Bean = await response.json();
+      // KVに保存した画像が取得できるようになるまで時間がかかるため、ローカルの写真があれば表示する。
+      createdBean.photo_data_url = newBean.photo_data_url;
       // 作成されたIDで更新
       setBeans([...beans, createdBean]);
       navigate(`/beans/${createdBean.id}`);

--- a/src/pages/BeanList.tsx
+++ b/src/pages/BeanList.tsx
@@ -10,7 +10,7 @@ interface BeanListItemProps {
 const BeanListItem: React.FC<BeanListItemProps> = ({ bean }) => {
   return (
     <li key={bean.id} className="p-4 border rounded-md flex items-center">
-      {bean.photo_data_url || bean.photo_url && (
+      {(bean.photo_data_url || bean.photo_url) && (
         <img
           src={bean.photo_data_url || bean.photo_url}
           alt={bean.name}


### PR DESCRIPTION
- Updated `BeanDetails` and `BeanList` components to prioritize `photo_data_url` over `photo_url` for displaying photos.
- Added fallback to use `photo_url` if `photo_data_url` is not available.
- Adjusted styling in `BeanForm` to add margin-bottom (`mb-4`) for improved spacing.
- Improved overall user experience by ensuring photos display promptly using local data when available.