### PR TITLE
refactor: Replace `brew_date` with `created_at` for consistency

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -26,13 +26,13 @@ CREATE TABLE IF NOT EXISTS beans (
     photo_url TEXT,
     notes TEXT,
     user_id INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 -- 抽出記録テーブル
 CREATE TABLE IF NOT EXISTS brews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    brew_date DATETIME NOT NULL,
     bean_id INTEGER NOT NULL,
     bean_amount INTEGER,
     cups INTEGER,
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS brews (
     sweetness INTEGER,
     notes TEXT,
     user_id INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (bean_id) REFERENCES beans (id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
@@ -56,6 +57,7 @@ CREATE TABLE IF NOT EXISTS settings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     settings JSON NOT NULL,
     user_id INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
@@ -69,9 +71,9 @@ VALUES
 (1, 'メキシコ オアハカ ハニー', 'メキシコ', 'オアハカ', 'ペタテドライ', 'ハニー', '中煎り', '', '', 1),
 (2, 'オリエンテナチュラル', 'グアテマラ', 'オリエンテ', 'ナチュラル', 'ナチュラル', '浅煎り', '', '', 1);
 
-INSERT INTO brews (id, brew_date, bean_id, bean_amount, grind_size, cups, water_temp, bloom_water_amount, bloom_time, pours, overall_score, bitterness, acidity, sweetness, notes, user_id)
+INSERT INTO brews (id, bean_id, bean_amount, grind_size, cups, water_temp, bloom_water_amount, bloom_time, pours, overall_score, bitterness, acidity, sweetness, notes, user_id)
 VALUES
-(1, '2024-12-29T23:00:00.000Z', 1, 20, '中細', 2, 85, 55, 45, '[140, 220, 300]', 4, 3, 2, 4, 'フルーティーでおいしい', 1);
+(1, 1, 20, '中細', 2, 85, 55, 45, '[140, 220, 300]', 4, 3, 2, 4, 'フルーティーでおいしい', 1);
 
 INSERT INTO settings (id, settings, user_id)
 VALUES

--- a/src/pages/BrewDetails.tsx
+++ b/src/pages/BrewDetails.tsx
@@ -54,7 +54,7 @@ const BrewDetails: React.FC = () => {
       </div>
 
       <div className="space-y-4">
-        <p><strong>日付:</strong> {formatLocalDateTime(brew.brew_date)}</p>
+        <p><strong>日付:</strong> {formatLocalDateTime(brew.created_at)}</p>
         {brew.bean && (<p><strong>豆:</strong> <Link to={`/beans/${brew.bean_id}`} className="text-blue-500 hover:underline">{brew.bean?.name}</Link></p>)}
         {isPositive(brew.bean_amount) && (<p><strong>豆の量:</strong> {brew.bean_amount} [g]</p>)}
         {isPositive(brew.cups) && (<p><strong>カップ数:</strong> {brew.cups}</p>)}

--- a/src/pages/BrewForm.tsx
+++ b/src/pages/BrewForm.tsx
@@ -11,7 +11,7 @@ const BrewForm: React.FC = () => {
   const { beans, brews, updateBrew, setBrews } = useBrewContext();
   const { brewId, beanId, baseBrewId } = useParams<{ brewId?: string; beanId?: string; baseBrewId?: string }>();
   const [bean, setBean] = useState<Bean | undefined>(undefined);
-  const [brew, setBrew] = useState<Brew>({ brew_date: new Date().toISOString() });
+  const [brew, setBrew] = useState<Brew>({ created_at: new Date().toISOString() });
   const [baseBrew, setBaseBrew] = useState<Brew>();
   const { settings } = useSettingsContext();
   
@@ -30,7 +30,7 @@ const BrewForm: React.FC = () => {
       setBaseBrew(baseBrew);
       setBean(baseBrew.bean);
       // 新しく作るので日付をリセット
-      setBrew({ ...baseBrew, brew_date: new Date().toISOString() });
+      setBrew({ ...baseBrew, created_at: new Date().toISOString() });
     }
   }, [brewId, beanId, baseBrewId, beans, brews]);
 

--- a/src/pages/BrewList.tsx
+++ b/src/pages/BrewList.tsx
@@ -12,7 +12,7 @@ export const BrewListItem: React.FC<BrewListItemProps> = ({ brew }) => {
   return (
     <li key={brew.id} className="p-4 border rounded-md">
       <Link to={`/brews/${brew.id}`} className="text-blue-500 hover:underline">
-        <h2 className="font-bold">{formatLocalDateTime(brew.brew_date)}</h2>
+        <h2 className="font-bold">{formatLocalDateTime(brew.created_at)}</h2>
         <p>豆: {brew.bean?.name}</p>
         {(brew.overall_score != null && brew.overall_score > 0) && (<p>評価: {'★'.repeat(brew.overall_score ?? 0)}</p>)}
       </Link>

--- a/src/types/Brew.ts
+++ b/src/types/Brew.ts
@@ -2,7 +2,6 @@ import { Bean } from "./Bean";
 
 export interface Brew {
   id?: number;
-  brew_date: string;
   bean?: Bean;
   bean_id?: number;
   cups?: number;
@@ -17,6 +16,7 @@ export interface Brew {
   acidity?: number;
   sweetness?: number;
   notes?: string;
+  created_at?: string;
 }
 
 export const totalWaterAmount = (brew: Brew, pourIndex: number): number => {


### PR DESCRIPTION
- Added `created_at` with `DEFAULT CURRENT_TIMESTAMP` to `beans`, `brews`, and `settings` tables in the database schema.
- Removed `brew_date` from the `brews` table and updated associated SQL queries.
- Modified API endpoints to handle `created_at` instead of `brew_date`.
- Updated frontend components (`BrewDetails`, `BrewForm`, `BrewList`) to use `created_at` for displaying and processing brew timestamps.
- Adjusted the `Brew` interface to reflect the removal of `brew_date`.

These changes improve naming consistency and timestamp handling across the application.