### PR TITLE
Add sign-out functionality and beans page link

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ const Navbar: React.FC = () => {
       <div className="container mx-auto flex justify-between">
         <Link to="/" className="text-white text-lg font-semibold">豆ログ</Link>
         <div className="flex space-x-4">
+          <Link to="/beans" className="text-gray-300 hover:text-white">豆</Link>
           <Link to="/brews" className="text-gray-300 hover:text-white">抽出ログ</Link>
           <Link to="/settings" className="text-gray-300 hover:text-white">設定</Link>
         </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useSettingsContext } from '../context/SettingsContext';
 import { isFixedOption, isDynamicOption } from '../types/Settings';
 import FixedOptionEditor from '../components/settings/FixedOptionEditor';
 import DynamicOptionEditor from '../components/settings/DynamicOptionEditor';
+import { signOut } from '@hono/auth-js/react';
 
 const Settings: React.FC = () => {
   const { settings, updateSettings, saveSettings, loadSettings } = useSettingsContext();
@@ -29,7 +30,13 @@ const Settings: React.FC = () => {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">設定を変更</h1>
+      <button
+        onClick={() => signOut()}
+        className="px-4 py-2 border flex gap-2 border-slate-300 dark:border-slate-700 rounded-lg text-slate-700 dark:text-slate-200 hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-900 dark:hover:text-slate-300 hover:shadow transition duration-150"
+      >
+        サインアウト
+      </button>
+      <h1 className="text-2xl font-bold mt-4 mb-4">設定を変更</h1>
       <form className="space-y-6" onSubmit={(e) => { e.preventDefault(); handleSave(); }}>
         {Object.entries(settings).map(([key, setting]) => (
           <div key={key} className="mb-6 border p-4 rounded-md">


### PR DESCRIPTION
This pull request introduces the following enhancements:

1. **Sign-out Button in Settings Page**:
   - Integrated `signOut` functionality from `@hono/auth-js/react`.
   - Added a sign-out button to the Settings page with appropriate styling for both light and dark themes.
   - Adjusted the layout to maintain proper spacing and visual hierarchy.

2. **Link to Beans Page in Navbar**:
   - Added a new link to the `/beans` page in the Navbar.
   - Maintained consistent styling with other navigation links, including hover effects.

These changes improve user experience by enabling account sign-out and providing quick access to the beans page.