### PR TITLE
Refactor photo key generation and handling logic for beans API and BeanForm page

### DIFF
--- a/src/api/users/beans.ts
+++ b/src/api/users/beans.ts
@@ -21,7 +21,13 @@ const beanSchema = z.object({
   })).optional()
 });
 
-const getPhotoKey = (photo_url: string | undefined): string => photo_url || `/api/users/images/coffee-labels/${crypto.randomUUID()}.png`;
+const getPhotoKey = (photo_data_url: string, photo_url: string): string => {
+  if (!photo_data_url.trim() || !photo_url.trim()) {
+    return '';
+  }
+  return `/api/users/images/coffee-labels/${crypto.randomUUID()}.png`;
+};
+
 
 const updatePhoto = async (c: Context, user_id: string, photoKey: string, photo_data_url: string | undefined) => {
   if (!photo_data_url) return;
@@ -52,8 +58,8 @@ app.post('/', async (c: Context<{ Bindings: Env }>) => {
       tags = []
     } = parsedBean;
 
-    const photoKey = getPhotoKey(photo_url);
-
+    const photoKey = getPhotoKey(photo_data_url, photo_url);
+    console.log(photo_data_url, photo_url, photoKey)
     updatePhoto(c, user.id, photoKey, photo_data_url);
 
     const result = await c.env.DB.prepare(
@@ -196,7 +202,7 @@ app.put('/:id', async (c: Context<{ Bindings: Env }>) => {
       tags = []
     } = parsedBean;
 
-    const photoKey = getPhotoKey(photo_url);
+    const photoKey = getPhotoKey(photo_data_url, photo_url);
 
     updatePhoto(c, user.id, photoKey, photo_data_url);
 

--- a/src/pages/BeanForm.tsx
+++ b/src/pages/BeanForm.tsx
@@ -58,7 +58,7 @@ const BeanForm: React.FC = () => {
   
       const createdBean: Bean = await response.json();
       // KVに保存した画像が取得できるようになるまで時間がかかるため、ローカルの写真があれば表示する。
-      createdBean.photo_data_url = newBean.photo_data_url;
+      createdBean.photo_data_url = newBean.photo_data_url || '';
       // 作成されたIDで更新
       setBeans([...beans, createdBean]);
       navigate(`/beans/${createdBean.id}`);


### PR DESCRIPTION
- Updated `getPhotoKey` function to handle both `photo_data_url` and `photo_url` parameters with improved validation.
- Ensured empty strings are handled correctly to prevent unnecessary photo key generation.
- Adjusted `updatePhoto` calls in `beans.ts` to use the new `getPhotoKey` function signature.
- Added a fallback for `photo_data_url` in the `BeanForm` page to prevent undefined values during bean creation.
- Included debug logging for `photo_data_url`, `photo_url`, and generated `photoKey` for better traceability during API calls.