### PR TITLE
Enhance Brew Logging with `created_at` Timestamps and Schema Improvements

### DIFF
--- a/src/api/users/analyze.ts
+++ b/src/api/users/analyze.ts
@@ -19,7 +19,6 @@ async function handleGemini(base64Data: string, env: Env): Promise<Response> {
 - メモ (notes)
 
 出力形式はJSONでお願いします。含まれていない項目はNULLではなく""にしてください。
-purchase_dateとroast_dateは日付形式でお願いします。例: "2022-01-01"
 `;
 
   const generationConfig = {

--- a/src/pages/BrewForm.tsx
+++ b/src/pages/BrewForm.tsx
@@ -12,7 +12,7 @@ const BrewForm: React.FC = () => {
   const { beans, brews, updateBrew, setBrews } = useBrewContext();
   const { brewId, beanId, baseBrewId } = useParams<{ brewId?: string; beanId?: string; baseBrewId?: string }>();
   const [bean, setBean] = useState<Bean | undefined>(undefined);
-  const [brew, setBrew] = useState<Brew>({ created_at: new Date().toISOString() });
+  const [brew, setBrew] = useState<Brew>({});
   const [baseBrew, setBaseBrew] = useState<Brew>();
   const { settings } = useSettingsContext();
   
@@ -30,8 +30,8 @@ const BrewForm: React.FC = () => {
       if (!baseBrew) return;
       setBaseBrew(baseBrew);
       setBean(baseBrew.bean);
-      // 新しく作るので日付をリセット
-      setBrew({ ...baseBrew, created_at: new Date().toISOString() });
+      // 新しく作るのでIDと日付をリセット
+      setBrew({ ...baseBrew, id: undefined, created_at: undefined });
     }
   }, [brewId, beanId, baseBrewId, beans, brews]);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -22,9 +22,9 @@ export const fromUtcToLocalDate = (utcDateString: string | undefined): string =>
   return localDate.toISOString().slice(0, 10);
 };
 
-export const formatLocalDate = (isoDate: string | undefined) => {
-  if (!isoDate) return '';
-  const date = new Date(isoDate);
+export const formatLocalDate = (utcDatetime: string | undefined) => {
+  if (!utcDatetime) return '';
+  const date = new Date(utcDatetime + 'Z');
   return date.toLocaleDateString(undefined, {
     year: 'numeric',
     month: '2-digit',
@@ -32,9 +32,9 @@ export const formatLocalDate = (isoDate: string | undefined) => {
   });
 };
 
-export const formatLocalDateTime = (isoDate: string | undefined) => {
-  if (!isoDate) return '';
-  const date = new Date(isoDate);
+export const formatLocalDateTime = (utcDatetime: string | undefined) => {
+  if (!utcDatetime) return '';
+  const date = new Date(utcDatetime + 'Z');
   return date.toLocaleDateString(undefined, {
     year: 'numeric',
     month: '2-digit',


### PR DESCRIPTION
This PR introduces several enhancements and fixes across multiple files to improve the brew logging functionality:

- **`created_at` Timestamps**: 
  - Added support for `created_at` timestamps in brew creation. This ensures accurate tracking of when brews are created.
  - Automatically generates the current UTC datetime during brew creation in the API.

- **Database Schema Updates**:
  - Updated the `brews` table to include a `created_at` column.
  - Modified the `INSERT` query logic to store the `created_at` timestamp.

- **API Changes**:
  - Adjusted `brewSchema` in the backend to accommodate the new `created_at` field.

- **Frontend Updates**:
  - Updated the `BrewForm` component to reset `id` and `created_at` when creating a new brew from an existing one.
  - Removed default initialization of `created_at` in the state for flexibility.

- **Cleanup**:
  - Removed redundant instructions for date formats in `handleGemini` API.

These changes improve the overall robustness of the application by ensuring better data consistency and traceability.