### PR TITLE
Refactor getPhotoKey logic to prioritize photo_url over photo_data_url

### DIFF
--- a/src/api/users/beans.ts
+++ b/src/api/users/beans.ts
@@ -23,12 +23,14 @@ const beanSchema = z.object({
 });
 
 const getPhotoKey = (photo_data_url: string, photo_url: string): string => {
-  if (!photo_data_url.trim() || !photo_url.trim()) {
-    return '';
+  if (photo_url.trim()) {
+    return photo_url;
   }
-  return `/api/users/images/coffee-labels/${crypto.randomUUID()}.png`;
+  if (photo_data_url.trim()) {
+    return `/api/users/images/coffee-labels/${crypto.randomUUID()}.png`;
+  }
+  return '';
 };
-
 
 const updatePhoto = async (c: Context, user_id: string, photoKey: string, photo_data_url: string | undefined) => {
   if (!photo_data_url) return;
@@ -60,7 +62,6 @@ app.post('/', async (c: Context<{ Bindings: Env }>) => {
     } = parsedBean;
 
     const photoKey = getPhotoKey(photo_data_url, photo_url);
-    console.log(photo_data_url, photo_url, photoKey)
     updatePhoto(c, user.id, photoKey, photo_data_url);
 
     const result = await c.env.DB.prepare(


### PR DESCRIPTION
- Updated `getPhotoKey` to return `photo_url` if it exists and is non-empty.
- Added fallback logic to generate a new `.png` key only when `photo_data_url` is present.
- Ensures an empty string is returned when both `photo_url` and `photo_data_url` are empty.
- Removed debugging `console.log` statement for cleaner code.